### PR TITLE
Add threshold network API precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "emsdk"
 version = "0.1.1"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "fs_extra",
  "reqwest",
@@ -1161,13 +1161,13 @@ dependencies = [
 [[package]]
 name = "fhe_precompiles"
 version = "0.1.0"
-source = "git+https://github.com/Sunscreen-tech/fhe_precompiles?rev=c3a2c184eb8ef7a136cc79f9e43567025d431be8#c3a2c184eb8ef7a136cc79f9e43567025d431be8"
 dependencies = [
  "bincode",
  "crypto-bigint",
  "libc",
  "once_cell",
  "paste",
+ "sha2 0.10.7",
  "sunscreen",
 ]
 
@@ -2961,7 +2961,7 @@ dependencies = [
 [[package]]
 name = "seal_fhe"
 version = "0.7.0"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "bindgen",
  "cmake",
@@ -3320,7 +3320,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sunscreen"
 version = "0.7.0"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "bumpalo",
  "crypto-bigint",
@@ -3344,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "sunscreen_backend"
 version = "0.7.0"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "crossbeam",
  "env_logger",
@@ -3360,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "sunscreen_bulletproofs"
 version = "4.0.0"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "byteorder",
  "clear_on_drop",
@@ -3379,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "sunscreen_compiler_common"
 version = "0.7.0"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "petgraph",
  "proc-macro2 1.0.66",
@@ -3394,7 +3394,7 @@ dependencies = [
 [[package]]
 name = "sunscreen_compiler_macros"
 version = "0.7.0"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "sunscreen_curve25519"
 version = "4.1.1"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -3419,7 +3419,7 @@ dependencies = [
 [[package]]
 name = "sunscreen_fhe_program"
 version = "0.7.0"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "petgraph",
  "seal_fhe",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "sunscreen_runtime"
 version = "0.7.0"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "bincode",
  "crossbeam",
@@ -3454,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "sunscreen_zkp_backend"
 version = "0.1.0"
-source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=4018eab87de46718e05ab9400873c338671b9f83#4018eab87de46718e05ab9400873c338671b9f83"
+source = "git+https://github.com/Sunscreen-tech/Sunscreen?rev=e90c11910cf6651a6d56bceb61d3f935cc7a1674#e90c11910cf6651a6d56bceb61d3f935cc7a1674"
 dependencies = [
  "bumpalo",
  "crypto-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,7 @@ dependencies = [
 [[package]]
 name = "fhe_precompiles"
 version = "0.1.0"
+source = "git+https://github.com/Sunscreen-tech/fhe_precompiles?rev=5f365a7d47a779dcf5c8fd731f1b0c09bda440ea#5f365a7d47a779dcf5c8fd731f1b0c09bda440ea"
 dependencies = [
  "bincode",
  "crypto-bigint",

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -21,7 +21,8 @@ secp256k1 = { version = "0.27.0", default-features = false, features = [
 ], optional = true }
 sha2 = { version = "0.10.5", default-features = false }
 sha3 = { version = "0.10.7", default-features = false }
-fhe_precompiles = { git = "https://github.com/Sunscreen-tech/fhe_precompiles", rev = "c3a2c184eb8ef7a136cc79f9e43567025d431be8" }
+# fhe_precompiles = { git = "https://github.com/Sunscreen-tech/fhe_precompiles", rev = "c3a2c184eb8ef7a136cc79f9e43567025d431be8" }
+fhe_precompiles = { path = "/Users/ryan/code/fhe_precompiles" }
 
 [dev-dependencies]
 hex = "0.4"

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -21,8 +21,7 @@ secp256k1 = { version = "0.27.0", default-features = false, features = [
 ], optional = true }
 sha2 = { version = "0.10.5", default-features = false }
 sha3 = { version = "0.10.7", default-features = false }
-# fhe_precompiles = { git = "https://github.com/Sunscreen-tech/fhe_precompiles", rev = "c3a2c184eb8ef7a136cc79f9e43567025d431be8" }
-fhe_precompiles = { path = "/Users/ryan/code/fhe_precompiles" }
+fhe_precompiles = { git = "https://github.com/Sunscreen-tech/fhe_precompiles", rev = "5f365a7d47a779dcf5c8fd731f1b0c09bda440ea" }
 
 [dev-dependencies]
 hex = "0.4"

--- a/crates/precompile/src/fhe.rs
+++ b/crates/precompile/src/fhe.rs
@@ -28,6 +28,7 @@ pub const COST_FHE_SUB_PLAIN: u64 = 200;
 pub const COST_FHE_MUL: u64 = 1000;
 pub const COST_FHE_MUL_PLAIN: u64 = 200;
 
+pub const COST_FHE_NETWORK_KEY: u64 = 0;
 pub const COST_FHE_ENCRYPT: u64 = 1000;
 pub const COST_FHE_REENCRYPT: u64 = 2000;
 
@@ -507,6 +508,18 @@ pub const FHE_MUL_FRAC64_CIPHERFRAC64: PrecompileAddress = PrecompileAddress(
 /**************************************************************************
  * Network API
  *************************************************************************/
+
+pub const FHE_NETWORK_PUBLIC_KEY: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(
+            |x| FHE.public_key_bytes(x),
+            input,
+            COST_FHE_NETWORK_KEY,
+            gas_limit,
+        )
+    }),
+);
 
 // Encrypt ////////////////////////////////////////////////////////////////
 

--- a/crates/precompile/src/fhe.rs
+++ b/crates/precompile/src/fhe.rs
@@ -18,8 +18,9 @@ pub const FHE_SUB_ADDRESS: u64 = 0x10;
 pub const FHE_MUL_ADDRESS: u64 = 0x20;
 
 pub const FHE_NETWORK_API_ADDRESS: u64 = 0x01_00_00_00;
-pub const FHE_ENCRYPT_ADDRESS: u64 = 0x00_00_00_00;
-pub const FHE_REENCRYPT_ADDRESS: u64 = 0x00_00_00_10;
+pub const FHE_NETWORK_KEY_ADDRESS: u64 = 0x00_00_00_00;
+pub const FHE_ENCRYPT_ADDRESS: u64 = 0x00_00_00_10;
+pub const FHE_REENCRYPT_ADDRESS: u64 = 0x00_00_00_20;
 
 pub const COST_FHE_ADD: u64 = 200;
 pub const COST_FHE_ADD_PLAIN: u64 = 200;
@@ -510,7 +511,7 @@ pub const FHE_MUL_FRAC64_CIPHERFRAC64: PrecompileAddress = PrecompileAddress(
  *************************************************************************/
 
 pub const FHE_NETWORK_PUBLIC_KEY: PrecompileAddress = PrecompileAddress(
-    u64_to_b160(FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS),
+    u64_to_b160(FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_NETWORK_KEY_ADDRESS),
     Precompile::Custom(|input, gas_limit| {
         to_precompile(
             |x| FHE.public_key_bytes(x),

--- a/crates/precompile/src/fhe.rs
+++ b/crates/precompile/src/fhe.rs
@@ -17,12 +17,21 @@ pub const FHE_ADD_ADDRESS: u64 = 0x00;
 pub const FHE_SUB_ADDRESS: u64 = 0x10;
 pub const FHE_MUL_ADDRESS: u64 = 0x20;
 
+pub const FHE_NETWORK_API_ADDRESS: u64 = 0x01_00_00_00;
+pub const FHE_ENCRYPT_ADDRESS: u64 = 0x00_00_00_00;
+pub const FHE_REENCRYPT_ADDRESS: u64 = 0x00_00_00_10;
+pub const FHE_REFRESH_ADDRESS: u64 = 0x00_00_00_20;
+
 pub const COST_FHE_ADD: u64 = 200;
 pub const COST_FHE_ADD_PLAIN: u64 = 200;
 pub const COST_FHE_SUB: u64 = 200;
 pub const COST_FHE_SUB_PLAIN: u64 = 200;
 pub const COST_FHE_MUL: u64 = 1000;
 pub const COST_FHE_MUL_PLAIN: u64 = 200;
+
+pub const COST_FHE_ENCRYPT: u64 = 1000;
+pub const COST_FHE_REENCRYPT: u64 = 2000;
+pub const COST_FHE_REFRESH: u64 = 2000;
 
 fn to_error(value: FheError) -> Error {
     match value {
@@ -32,6 +41,8 @@ fn to_error(value: FheError) -> Error {
         }
         FheError::InvalidEncoding => Error::Other("Invalid bincode encoding".into()),
         FheError::Overflow => Error::Other("i64 overflow".into()),
+        FheError::FailedDecryption => Error::Other("Failed decryption".into()),
+        FheError::FailedEncryption => Error::Other("Failed Encryption".into()),
         FheError::SunscreenError(e) => Error::Other(format!("Sunscreen error: {:?}", e).into()),
     }
 }
@@ -44,7 +55,7 @@ where
         return Err(Error::OutOfGas);
     }
 
-    f(input).map(|x| (op_cost, x)).map_err(|e| to_error(e))
+    f(input).map(|x| (op_cost, x)).map_err(to_error)
 }
 
 /**************************************************************************
@@ -490,6 +501,146 @@ pub const FHE_MUL_FRAC64_CIPHERFRAC64: PrecompileAddress = PrecompileAddress(
             |x| FHE.mul_frac64_cipherfrac64(x),
             input,
             COST_FHE_MUL_PLAIN,
+            gas_limit,
+        )
+    }),
+);
+
+/**************************************************************************
+ * Network API
+ *************************************************************************/
+
+// Encrypt ////////////////////////////////////////////////////////////////
+
+pub const FHE_ENCRYPT_U256: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(
+        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_U256_ADDRESS + FHE_ENCRYPT_ADDRESS,
+    ),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(|x| FHE.encrypt_u256(x), input, COST_FHE_ENCRYPT, gas_limit)
+    }),
+);
+
+pub const FHE_ENCRYPT_U64: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_U64_ADDRESS + FHE_ENCRYPT_ADDRESS),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(|x| FHE.encrypt_u64(x), input, COST_FHE_ENCRYPT, gas_limit)
+    }),
+);
+
+pub const FHE_ENCRYPT_I64: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_I64_ADDRESS + FHE_ENCRYPT_ADDRESS),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(|x| FHE.encrypt_i64(x), input, COST_FHE_ENCRYPT, gas_limit)
+    }),
+);
+
+pub const FHE_ENCRYPT_FRAC64: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(
+        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_FRAC64_ADDRESS + FHE_ENCRYPT_ADDRESS,
+    ),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(
+            |x| FHE.encrypt_frac64(x),
+            input,
+            COST_FHE_ENCRYPT,
+            gas_limit,
+        )
+    }),
+);
+
+// Reencrypt //////////////////////////////////////////////////////////////
+
+pub const FHE_REENCRYPT_U256: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(
+        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_U256_ADDRESS + FHE_REENCRYPT_ADDRESS,
+    ),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(
+            |x| FHE.reencrypt_u256(x),
+            input,
+            COST_FHE_REENCRYPT,
+            gas_limit,
+        )
+    }),
+);
+
+pub const FHE_REENCRYPT_U64: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(
+        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_U64_ADDRESS + FHE_REENCRYPT_ADDRESS,
+    ),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(
+            |x| FHE.reencrypt_u64(x),
+            input,
+            COST_FHE_REENCRYPT,
+            gas_limit,
+        )
+    }),
+);
+
+pub const FHE_REENCRYPT_I64: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(
+        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_I64_ADDRESS + FHE_REENCRYPT_ADDRESS,
+    ),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(
+            |x| FHE.reencrypt_i64(x),
+            input,
+            COST_FHE_REENCRYPT,
+            gas_limit,
+        )
+    }),
+);
+
+pub const FHE_REENCRYPT_FRAC64: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(
+        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_FRAC64_ADDRESS + FHE_REENCRYPT_ADDRESS,
+    ),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(
+            |x| FHE.reencrypt_frac64(x),
+            input,
+            COST_FHE_REENCRYPT,
+            gas_limit,
+        )
+    }),
+);
+
+// Refresh ////////////////////////////////////////////////////////////////
+
+pub const FHE_REFRESH_U256: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(
+        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_U256_ADDRESS + FHE_REFRESH_ADDRESS,
+    ),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(|x| FHE.refresh_u256(x), input, COST_FHE_REFRESH, gas_limit)
+    }),
+);
+
+pub const FHE_REFRESH_U64: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_U64_ADDRESS + FHE_REFRESH_ADDRESS),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(|x| FHE.refresh_u64(x), input, COST_FHE_REFRESH, gas_limit)
+    }),
+);
+
+pub const FHE_REFRESH_I64: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_I64_ADDRESS + FHE_REFRESH_ADDRESS),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(|x| FHE.refresh_i64(x), input, COST_FHE_REFRESH, gas_limit)
+    }),
+);
+
+pub const FHE_REFRESH_FRAC64: PrecompileAddress = PrecompileAddress(
+    u64_to_b160(
+        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_FRAC64_ADDRESS + FHE_REFRESH_ADDRESS,
+    ),
+    Precompile::Custom(|input, gas_limit| {
+        to_precompile(
+            |x| FHE.refresh_frac64(x),
+            input,
+            COST_FHE_REFRESH,
             gas_limit,
         )
     }),

--- a/crates/precompile/src/fhe.rs
+++ b/crates/precompile/src/fhe.rs
@@ -20,7 +20,6 @@ pub const FHE_MUL_ADDRESS: u64 = 0x20;
 pub const FHE_NETWORK_API_ADDRESS: u64 = 0x01_00_00_00;
 pub const FHE_ENCRYPT_ADDRESS: u64 = 0x00_00_00_00;
 pub const FHE_REENCRYPT_ADDRESS: u64 = 0x00_00_00_10;
-pub const FHE_REFRESH_ADDRESS: u64 = 0x00_00_00_20;
 
 pub const COST_FHE_ADD: u64 = 200;
 pub const COST_FHE_ADD_PLAIN: u64 = 200;
@@ -31,7 +30,6 @@ pub const COST_FHE_MUL_PLAIN: u64 = 200;
 
 pub const COST_FHE_ENCRYPT: u64 = 1000;
 pub const COST_FHE_REENCRYPT: u64 = 2000;
-pub const COST_FHE_REFRESH: u64 = 2000;
 
 fn to_error(value: FheError) -> Error {
     match value {
@@ -602,45 +600,6 @@ pub const FHE_REENCRYPT_FRAC64: PrecompileAddress = PrecompileAddress(
             |x| FHE.reencrypt_frac64(x),
             input,
             COST_FHE_REENCRYPT,
-            gas_limit,
-        )
-    }),
-);
-
-// Refresh ////////////////////////////////////////////////////////////////
-
-pub const FHE_REFRESH_U256: PrecompileAddress = PrecompileAddress(
-    u64_to_b160(
-        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_U256_ADDRESS + FHE_REFRESH_ADDRESS,
-    ),
-    Precompile::Custom(|input, gas_limit| {
-        to_precompile(|x| FHE.refresh_u256(x), input, COST_FHE_REFRESH, gas_limit)
-    }),
-);
-
-pub const FHE_REFRESH_U64: PrecompileAddress = PrecompileAddress(
-    u64_to_b160(FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_U64_ADDRESS + FHE_REFRESH_ADDRESS),
-    Precompile::Custom(|input, gas_limit| {
-        to_precompile(|x| FHE.refresh_u64(x), input, COST_FHE_REFRESH, gas_limit)
-    }),
-);
-
-pub const FHE_REFRESH_I64: PrecompileAddress = PrecompileAddress(
-    u64_to_b160(FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_I64_ADDRESS + FHE_REFRESH_ADDRESS),
-    Precompile::Custom(|input, gas_limit| {
-        to_precompile(|x| FHE.refresh_i64(x), input, COST_FHE_REFRESH, gas_limit)
-    }),
-);
-
-pub const FHE_REFRESH_FRAC64: PrecompileAddress = PrecompileAddress(
-    u64_to_b160(
-        FHE_BASE_ADDRESS + FHE_NETWORK_API_ADDRESS + FHE_FRAC64_ADDRESS + FHE_REFRESH_ADDRESS,
-    ),
-    Precompile::Custom(|input, gas_limit| {
-        to_precompile(
-            |x| FHE.refresh_frac64(x),
-            input,
-            COST_FHE_REFRESH,
             gas_limit,
         )
     }),

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -184,7 +184,6 @@ impl Precompiles {
                     // U256
                     fhe::FHE_ENCRYPT_U256,
                     fhe::FHE_REENCRYPT_U256,
-                    fhe::FHE_REFRESH_U256,
                     fhe::FHE_ADD_CIPHERU256_CIPHERU256,
                     fhe::FHE_ADD_CIPHERU256_U256,
                     fhe::FHE_ADD_U256_CIPHERU256,
@@ -197,7 +196,6 @@ impl Precompiles {
                     // U64
                     fhe::FHE_ENCRYPT_U64,
                     fhe::FHE_REENCRYPT_U64,
-                    fhe::FHE_REFRESH_U64,
                     fhe::FHE_ADD_CIPHERU64_CIPHERU64,
                     fhe::FHE_ADD_CIPHERU64_U64,
                     fhe::FHE_ADD_U64_CIPHERU64,
@@ -210,7 +208,6 @@ impl Precompiles {
                     // I64
                     fhe::FHE_ENCRYPT_I64,
                     fhe::FHE_REENCRYPT_I64,
-                    fhe::FHE_REFRESH_I64,
                     fhe::FHE_ADD_CIPHERI64_CIPHERI64,
                     fhe::FHE_ADD_CIPHERI64_I64,
                     fhe::FHE_ADD_I64_CIPHERI64,
@@ -223,7 +220,6 @@ impl Precompiles {
                     // FRAC64
                     fhe::FHE_ENCRYPT_FRAC64,
                     fhe::FHE_REENCRYPT_FRAC64,
-                    fhe::FHE_REFRESH_FRAC64,
                     fhe::FHE_ADD_CIPHERFRAC64_CIPHERFRAC64,
                     fhe::FHE_ADD_CIPHERFRAC64_FRAC64,
                     fhe::FHE_ADD_FRAC64_CIPHERFRAC64,

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -182,6 +182,9 @@ impl Precompiles {
             precompiles.fun.extend(
                 vec![
                     // U256
+                    fhe::FHE_ENCRYPT_U256,
+                    fhe::FHE_REENCRYPT_U256,
+                    fhe::FHE_REFRESH_U256,
                     fhe::FHE_ADD_CIPHERU256_CIPHERU256,
                     fhe::FHE_ADD_CIPHERU256_U256,
                     fhe::FHE_ADD_U256_CIPHERU256,
@@ -192,6 +195,9 @@ impl Precompiles {
                     fhe::FHE_MUL_CIPHERU256_U256,
                     fhe::FHE_MUL_U256_CIPHERU256,
                     // U64
+                    fhe::FHE_ENCRYPT_U64,
+                    fhe::FHE_REENCRYPT_U64,
+                    fhe::FHE_REFRESH_U64,
                     fhe::FHE_ADD_CIPHERU64_CIPHERU64,
                     fhe::FHE_ADD_CIPHERU64_U64,
                     fhe::FHE_ADD_U64_CIPHERU64,
@@ -202,6 +208,9 @@ impl Precompiles {
                     fhe::FHE_MUL_CIPHERU64_U64,
                     fhe::FHE_MUL_U64_CIPHERU64,
                     // I64
+                    fhe::FHE_ENCRYPT_I64,
+                    fhe::FHE_REENCRYPT_I64,
+                    fhe::FHE_REFRESH_I64,
                     fhe::FHE_ADD_CIPHERI64_CIPHERI64,
                     fhe::FHE_ADD_CIPHERI64_I64,
                     fhe::FHE_ADD_I64_CIPHERI64,
@@ -212,6 +221,9 @@ impl Precompiles {
                     fhe::FHE_MUL_CIPHERI64_I64,
                     fhe::FHE_MUL_I64_CIPHERI64,
                     // FRAC64
+                    fhe::FHE_ENCRYPT_FRAC64,
+                    fhe::FHE_REENCRYPT_FRAC64,
+                    fhe::FHE_REFRESH_FRAC64,
                     fhe::FHE_ADD_CIPHERFRAC64_CIPHERFRAC64,
                     fhe::FHE_ADD_CIPHERFRAC64_FRAC64,
                     fhe::FHE_ADD_FRAC64_CIPHERFRAC64,

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -229,6 +229,8 @@ impl Precompiles {
                     fhe::FHE_MUL_CIPHERFRAC64_CIPHERFRAC64,
                     fhe::FHE_MUL_CIPHERFRAC64_FRAC64,
                     fhe::FHE_MUL_FRAC64_CIPHERFRAC64,
+                    // Netowrk Public Key
+                    fhe::FHE_NETWORK_PUBLIC_KEY,
                     // EIP-2565: ModExp Gas Cost.
                     modexp::BERLIN,
                 ]


### PR DESCRIPTION
This will not work until https://github.com/Sunscreen-tech/fhe_precompiles/pull/15 is merged. 

I added a new namespace for the network API calls; we can change it.

Most important is probably the gas costs for now. I have some filler values in there; maybe we want to change them to something else.